### PR TITLE
merge stdout and stderr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.1.1",
       "dependencies": {
         "@wasmer/wasi": "1.2.2",
+        "colors": "^1.4.0",
         "dayjs": "1.11.8",
         "discord.js": "^14.8.0",
         "node-fetch": "3.3.1"
       },
       "devDependencies": {
+        "@types/colors": "^1.2.1",
         "eslint": "8.36.0",
         "eslint-config-prettier": "8.7.0",
         "eslint-plugin-import": "2.27.5",
@@ -244,6 +246,16 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
+    "node_modules/@types/colors": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
+      "deprecated": "This is a stub types definition. colors provides its own type definitions, so you don't need this installed.",
+      "dev": true,
+      "dependencies": {
+        "colors": "*"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -595,6 +607,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/commander": {
       "version": "10.0.0",
@@ -3517,6 +3537,15 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "@types/colors": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
+      "dev": true,
+      "requires": {
+        "colors": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -3773,6 +3802,11 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "commander": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@wasmer/wasi": "1.2.2",
+    "colors": "^1.4.0",
     "dayjs": "1.11.8",
     "discord.js": "^14.8.0",
     "node-fetch": "3.3.1"
   },
   "devDependencies": {
+    "@types/colors": "^1.2.1",
     "eslint": "8.36.0",
     "eslint-config-prettier": "8.7.0",
     "eslint-plugin-import": "2.27.5",

--- a/src/functions/runner/format.mjs
+++ b/src/functions/runner/format.mjs
@@ -1,4 +1,5 @@
-import { AttachmentBuilder, bold, codeBlock } from 'discord.js'
+import colors from 'colors'
+import { AttachmentBuilder, codeBlock } from 'discord.js'
 
 import { calcUploadSizeLimit, escapeBackQuote } from '../../util/message.mjs'
 
@@ -8,15 +9,14 @@ import { calcUploadSizeLimit, escapeBackQuote } from '../../util/message.mjs'
  * @returns {import('discord.js').MessageOptions}
  */
 export const generateSMResultReport = ({ stdout, stderr }, tier = 0) => {
-  stdout = (stdout ?? '').replace(/(^\n+|\n+$)/, '')
-  stderr = (stderr ?? '').replace(/(^\n+|\n+$)/, '')
-  const report = [
-    bold('出力'),
-    codeBlock('js', stdout ? escapeBackQuote(stdout) : '出力無し'),
-    bold('エラー出力'),
-    codeBlock('js', stderr ? escapeBackQuote(stderr) : '出力無し'),
-  ].join('\n')
+  /** @type {string[]} */
+  const out = []
+  if (stdout) out.push(stdout.replace(/(^\n+|\n+$)/, ''))
+  if (stderr) out.push(colors.red(stderr.replace(/(^\n+|\n+$)/, '')))
 
+  const report = out.length
+    ? codeBlock('ansi', escapeBackQuote(out.join('\n')))
+    : '出力無し'
   if (report.length <= 2000)
     return { content: report, allowedMentions: { repliedUser: true } }
 


### PR DESCRIPTION
出力が標準出力と標準エラーで分かれているとやたら行を食うという問題意識がありました．そこで，stderrに色をつけてansiコードブロックで表示することで，出力を1つにまとめるようにしました．

どうやらサンドボックス内では`console.error`が使えないようなので，標準エラーがあるならばそれは`throw`由来であり，つまり標準出力よりも後ろにあるため，まとめるには単純な文字列結合で事足ります．

<img width="983" alt="image" src="https://github.com/InkoHX/sm-discord-bot/assets/75649254/452be75d-3fc5-4951-86a5-4178fa1e6422">
