### PR TITLE
Mixed stdio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sm-discord-bot",
       "version": "1.1.1",
       "dependencies": {
-        "@wasmer/wasi": "1.2.2",
+        "@bjorn3/browser_wasi_shim": "^0.2.14",
         "colors": "^1.4.0",
         "dayjs": "1.11.8",
         "discord.js": "^14.8.0",
@@ -24,6 +24,11 @@
         "lint-staged": "13.2.0",
         "prettier": "2.8.7"
       }
+    },
+    "node_modules/@bjorn3/browser_wasi_shim": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.14.tgz",
+      "integrity": "sha512-1S0NNBgFqkogICDL7DOYmXLvxv4tlrjNZps6XNB7P8rr3XwXG1DqtfgYImERUzz71GirexUVrD/jQZht7swCzw=="
     },
     "node_modules/@discordjs/builders": {
       "version": "1.6.0",
@@ -275,11 +280,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@wasmer/wasi": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-1.2.2.tgz",
-      "integrity": "sha512-39ZB3gefOVhBmkhf7Ta79RRSV/emIV8LhdvcWhP/MOZEjMmtzoZWMzt7phdKj8CUXOze+AwbvGK60lKaKldn1w=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -3379,6 +3379,11 @@
     }
   },
   "dependencies": {
+    "@bjorn3/browser_wasi_shim": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.14.tgz",
+      "integrity": "sha512-1S0NNBgFqkogICDL7DOYmXLvxv4tlrjNZps6XNB7P8rr3XwXG1DqtfgYImERUzz71GirexUVrD/jQZht7swCzw=="
+    },
     "@discordjs/builders": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.0.tgz",
@@ -3564,11 +3569,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@wasmer/wasi": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-1.2.2.tgz",
-      "integrity": "sha512-39ZB3gefOVhBmkhf7Ta79RRSV/emIV8LhdvcWhP/MOZEjMmtzoZWMzt7phdKj8CUXOze+AwbvGK60lKaKldn1w=="
     },
     "acorn": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@wasmer/wasi": "1.2.2",
+    "@bjorn3/browser_wasi_shim": "^0.2.14",
     "colors": "^1.4.0",
     "dayjs": "1.11.8",
     "discord.js": "^14.8.0",

--- a/src/application-command/run.mjs
+++ b/src/application-command/run.mjs
@@ -114,10 +114,9 @@ export const execute = async interaction => {
     } catch (error) {
       if (error instanceof SMTimeoutError) {
         await modalInteraction.followUp(
-          generateSMResultReport({
-            stdout: null,
-            stderr: 'SM worker timed-out',
-          })
+          generateSMResultReport([
+            { fd: 'stderr', content: 'SM worker timed-out' },
+          ])
         )
 
         return

--- a/src/events/message-create.mjs
+++ b/src/events/message-create.mjs
@@ -65,10 +65,7 @@ const run = async (message, code) => {
   } catch (error) {
     if (!(error instanceof SMTimeoutError)) throw error
 
-    result = {
-      stdout: null,
-      stderr: 'SM worker timed-out',
-    }
+    result = [{ fd: 'stderr', content: 'SM worker timed-out' }]
   }
 
   const resultMessage = await message.reply({

--- a/src/functions/runner/runner.mjs
+++ b/src/functions/runner/runner.mjs
@@ -27,9 +27,15 @@ export const executeInSM = async (code, channel = releaseChannels.stable) => {
 
   await once(worker, 'online')
 
-  /** @type {{ fd: 'stdout' | 'stderr'; content: string }[]} */
+  /**
+   * 隣り合う2つの要素は，`fd`の値が異なるか，前の値が改行で終わっています．
+   * @type {{ fd: 'stdout' | 'stderr'; content: string }[]}
+   */
   const out = []
-  /** @type {{ fd: 'stdout' | 'stderr'; content: string } | undefined} */
+  /**
+   * 改行されるか，`fd`の値が変わるまでの出力をバッファリングします。
+   * @type {{ fd: 'stdout' | 'stderr'; content: string } | undefined}
+   */
   let current
   worker.on('message', message => {
     if (current?.fd === message.fd) {

--- a/src/functions/runner/runner.mjs
+++ b/src/functions/runner/runner.mjs
@@ -18,7 +18,7 @@ export class SMTimeoutError extends Error {
 /**
  * @param {string} code SpiderMonkeyで実行するJavaScript
  * @param {string} channel SpiderMonkeyのリリースチャンネル
- * @returns {Promise<{ stdout: string | null; stderr: string | null }>} コードの実行結果を返します。`null`を返せばタイムアウト
+ * @returns {Promise<{ fd: "stdout" | "stderr"; content: string }[]>} コードの実行結果を返します。
  */
 export const executeInSM = async (code, channel = releaseChannels.stable) => {
   const worker = new Worker(new URL(`./worker/index.mjs`, import.meta.url), {
@@ -27,14 +27,31 @@ export const executeInSM = async (code, channel = releaseChannels.stable) => {
 
   await once(worker, 'online')
 
-  const result = await Promise.race([
-    once(worker, 'message').then(([it]) => it),
+  /** @type {{ fd: 'stdout' | 'stderr'; content: string }[]} */
+  const out = []
+  /** @type {{ fd: 'stdout' | 'stderr'; content: string } | undefined} */
+  let current
+  worker.on('message', message => {
+    if (current?.fd === message.fd) {
+      current.content += message.content
+    } else {
+      if (current) out.push(current)
+      current = message
+    }
+    if (message.content.endsWith('\n')) {
+      out.push(current)
+      current = undefined
+    }
+  })
+
+  const exit = await Promise.race([
+    once(worker, 'exit'),
     setTimeout(10000)
       .then(() => worker.terminate())
       .then(() => null),
   ])
 
-  if (!result) throw new SMTimeoutError()
+  if (!exit) throw new SMTimeoutError()
 
-  return result
+  return out
 }

--- a/src/functions/runner/worker/index.mjs
+++ b/src/functions/runner/worker/index.mjs
@@ -1,48 +1,94 @@
 import fs from 'node:fs/promises'
 import { parentPort, workerData } from 'node:worker_threads'
 
-import { WASI, init } from '@wasmer/wasi'
+import {
+  WASI,
+  File,
+  OpenFile,
+  PreopenDirectory,
+  Fd,
+  // eslint-disable-next-line import/no-unresolved
+} from '@bjorn3/browser_wasi_shim'
 
-await init()
+class PortStdio extends Fd {
+  /**
+   * @param {'stdout' | 'stderr'} fd
+   */
+  constructor(fd) {
+    super()
+    /**
+     * @type {'stdout' | 'stderr'}
+     */
+    this.fd = fd
+  }
 
-const { channel, code } = workerData
-const runtimeModule = await WebAssembly.compile(
-  await fs.readFile(new URL(`./runtime/${channel}.wasm`, import.meta.url))
-)
-const wasi = new WASI({
-  args: [
-    '-f',
-    '/start.js',
-    '--selfhosted-xdr-path=/selfhosted.bin',
-    '--selfhosted-xdr-mode=encode',
-  ],
-  env: {},
-})
-
-await wasi.instantiate(runtimeModule, {})
-
-for (const file of await fs.readdir(new URL('./polyfill', import.meta.url))) {
-  const sourceCode = await fs.readFile(
-    new URL(`./polyfill/${file}`, import.meta.url),
-    'utf8'
-  )
-  const virtualFile = wasi.fs.open(`/${file}`, { write: true, create: true })
-
-  virtualFile.writeString(sourceCode)
-  virtualFile.seek(0)
+  /**
+   * @param {Uint8Array} view8
+   * @param {{ buf: number; buf_len: number }[]} iovs
+   * @returns {{ ret: number; nwritten: number }}
+   */
+  fd_write(view8, iovs) {
+    let nwritten = 0
+    for (const iovec of iovs) {
+      const buffer = view8.slice(iovec.buf, iovec.buf + iovec.buf_len)
+      const content = new TextDecoder().decode(buffer)
+      parentPort.postMessage({ fd: this.fd, content })
+      nwritten += buffer.length
+    }
+    return { ret: 0, nwritten }
+  }
 }
 
-const inputFile = wasi.fs.open('/input.js', { write: true, create: true })
-inputFile.writeString(code)
-inputFile.seek(0)
+const { channel, code } = workerData
+
+const args = [
+  '-f',
+  '/start.js',
+  '--selfhosted-xdr-path=/selfhosted.bin',
+  '--selfhosted-xdr-mode=encode',
+]
+const env = []
+const fds = [
+  new OpenFile(new File([])),
+  new PortStdio('stdout'),
+  new PortStdio('stderr'),
+]
+const wasi = new WASI(args, env, fds)
+
+async function prepareDir() {
+  /** {@type { [key: string]: File }} */
+  const contents = {
+    'input.js': new File(new TextEncoder().encode(code)),
+  }
+
+  const files = await fs.readdir(new URL('./polyfill', import.meta.url))
+  await Promise.all(
+    files.map(async file => {
+      const code = await fs.readFile(
+        new URL(`./polyfill/${file}`, import.meta.url)
+      )
+      contents[file] = new File(code)
+    })
+  )
+  return new PreopenDirectory('/', contents)
+}
+
+async function compile() {
+  const bin = await fs.readFile(
+    new URL(`./runtime/${channel}.wasm`, import.meta.url)
+  )
+  return await WebAssembly.compile(bin)
+}
+
+const [dir, wasm] = await Promise.all([prepareDir(), compile()])
+wasi.fds.push(dir)
+
+const inst = await WebAssembly.instantiate(wasm, {
+  wasi_snapshot_preview1: wasi.wasiImport,
+})
 
 try {
-  wasi.start()
+  wasi.start(inst)
 } catch (error) {
   /** コードに誤りがあったときに関係のないエラーを吐くため無視 */
 }
-
-parentPort.postMessage({
-  stdout: wasi.getStdoutString() || null,
-  stderr: wasi.getStderrString() || null,
-})


### PR DESCRIPTION
closes: #83 
`@wasmer/wasi`を[`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim)に置き換えることで，stdoutとstderrを混ぜてdumpすることができるように改造しました．
fd_writeされる文字列がかなり小刻みになっており，`colors.red()`で囲む際にANSIのエスケープが大量に出てくる問題があるため，そのあたりの処理が複雑になっています．