### PR TITLE
バグ修正：ワーカーのタイムアウト時に「出力無し」となってしまう件

### DIFF
--- a/src/functions/runner/runner.mjs
+++ b/src/functions/runner/runner.mjs
@@ -50,14 +50,17 @@ export const executeInSM = async (code, channel = releaseChannels.stable) => {
     }
   })
 
+  worker.on('error', console.error)
+
   const exit = await Promise.race([
     once(worker, 'exit'),
-    setTimeout(10000)
-      .then(() => worker.terminate())
-      .then(() => null),
+    setTimeout(10000).then(() => null),
   ])
 
-  if (!exit) throw new SMTimeoutError()
+  if (!exit) {
+    worker.terminate()
+    throw new SMTimeoutError()
+  }
 
   return out
 }


### PR DESCRIPTION
バグ：
`worker.terminate()` により status: 1 で worker が終了してしまい，
`once(worker, 'exit')` のほうが先に fulfilled になり，
「出力無し」となってしまう。

修正：
`await Promise.race(...)` の後で `worker.terminate()` をするように変更した。