### PR TITLE
バグ修正の試み：SpiderMonkey#8578 にて ANSI Escape が挿入されない件

### DIFF
--- a/src/functions/runner/format.mjs
+++ b/src/functions/runner/format.mjs
@@ -3,6 +3,9 @@ import { AttachmentBuilder, codeBlock } from 'discord.js'
 
 import { calcUploadSizeLimit, escapeBackQuote } from '../../util/message.mjs'
 
+// ANSI Escape による色付けを強制的に有効化
+colors.enable()
+
 /**
  * @param {{ fd: "stdout" | "stderr"; content: string }[]} out
  * @param {number} tier


### PR DESCRIPTION
npm ライブラリ「colors」は，気をきかせて
環境によって ANSI を付けたり付けなかったりするようなので
`colors.enable()` により有効化することで
バグを修正できるのではないか。
というものです。