### PR TITLE
🔧 extend ":disableRateLimiting"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":disableRateLimiting"],
   "assignees": ["InkoHX"],
   "commitMessageAction": "Update",
   "commitMessagePrefix": "⬆️",
+  "dependencyDashboardApproval": true,
   "packageRules": [
     {
       "matchUpdateTypes": "pin",
       "commitMessagePrefix": "📌",
+      "dependencyDashboardApproval": false,
       "automerge": true
     },
     {


### PR DESCRIPTION
レートリミットに引っかかると、automergeを期待しているPRも作成されないので、無効化しました。
ただ、これだとPRが溢れかえるので、automergeが有効になっているそれ以外ではPR作成を承認してから行うように変更しました。

https://docs.renovatebot.com/presets-default/#disableratelimiting https://docs.renovatebot.com/configuration-options/#dependencyDashboardApproval